### PR TITLE
upgrade target-platform to 2023-03 ide levels

### DIFF
--- a/releng/target-platform-1Q2023/target-platform-1Q2023.target
+++ b/releng/target-platform-1Q2023/target-platform-1Q2023.target
@@ -1,0 +1,126 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<?pde version="3.8"?>
+<!--
+  Copyright (c) 2022 IBM Corporation and others.
+  
+  This program and the accompanying materials are made available under the
+  terms of the Eclipse Public License v. 2.0 which is available at
+  http://www.eclipse.org/legal/epl-2.0.
+  
+  SPDX-License-Identifier: EPL-2.0
+  
+  Contributors:
+      IBM Corporation - initial implementation
+-->
+<target includeMode="feature" name="target-platform.target" sequenceNumber="15">
+    <locations>
+
+    <location includeAllPlatforms="false" includeMode="planner" includeSource="true" type="InstallableUnit">
+        <repository location="https://download.eclipse.org/wildwebdeveloper/releases/1.0.2/"/>
+        <unit id="org.eclipse.wildwebdeveloper.feature.feature.group" version="1.0.2.202302250247"/>
+      <unit id="org.eclipse.wildwebdeveloper.xml.feature.feature.group" version="1.0.2.202301201156"/>
+     </location>
+
+        <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
+            <repository location="https://download.eclipse.org/releases/2023-03/"/>
+            <unit id="org.eclipse.jdt.feature.group" version="3.19.0.v20230302-0300"/>
+            <unit id="org.eclipse.lsp4e" version="0.15.0.202211292024"/>
+            <unit id="org.eclipse.ui.trace" version="1.2.200.v20220310-2159"/>
+            <unit id="org.eclipse.lsp4e.jdt" version="0.10.2.202205031750"/>
+            <unit id="org.eclipse.emf.sdk.feature.group" version="2.33.0.v20230226-0921"/>
+            <unit id="org.eclipse.equinox.sdk.feature.group" version="3.23.700.v20230220-1352"/>
+            <unit id="org.eclipse.m2e.wtp.feature.feature.group" version="1.6.0.20230118-0812"/>
+            <unit id="org.eclipse.platform.sdk" version="4.27.0.I20230302-0300"/>
+            <unit id="org.eclipse.ui.trace" version="1.2.200.v20220310-2159"/>
+            <unit id="org.hamcrest.core" version="1.3.0.v20180420-1519"/>
+            <unit id="org.junit" version="4.13.2.v20211018-1956"/>
+            <unit id="junit-jupiter-api" version="5.9.2"/>
+            <unit id="junit-jupiter-engine" version="5.9.2"/>
+        </location>
+        <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
+            <repository location="https://download.eclipse.org/tools/orbit/downloads/drops/R20220531185310/repository"/>
+            <unit id="ch.qos.logback.slf4j" version="1.2.3.v20200428-2012"/>
+            <unit id="ch.qos.logback.slf4j.source" version="1.2.3.v20200428-2012"/>
+            <unit id="org.slf4j.api" version="1.7.30.v20200204-2150"/>
+            <unit id="org.slf4j.api.source" version="1.7.30.v20200204-2150"/>
+        </location>
+        <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
+            <repository location="https://download.eclipse.org/technology/swtbot/releases/3.1.0"/>
+            <unit id="org.eclipse.swtbot.eclipse.feature.group" version="3.1.0.202106041005"/>
+            <unit id="org.eclipse.swtbot.eclipse.test.junit.feature.group" version="3.1.0.202106041005"/>
+            <unit id="org.eclipse.swtbot.feature.group" version="3.1.0.202106041005"/>
+            <unit id="org.eclipse.swtbot.forms.feature.group" version="3.1.0.202106041005"/>
+            <unit id="org.eclipse.swtbot.ide.feature.group" version="3.1.0.202106041005"/>
+        </location>
+        <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
+            <repository location="https://download.eclipse.org/tools/cdt/releases/10.6"/>
+            <unit id="org.eclipse.tm.terminal.connector.cdtserial.feature.feature.group" version="10.6.2.202205081303"/>
+            <unit id="org.eclipse.tm.terminal.connector.cdtserial.feature.source.feature.group" version="10.6.2.202205081303"/>
+            <unit id="org.eclipse.tm.terminal.connector.local.feature.feature.group" version="10.6.2.202205081303"/>
+            <unit id="org.eclipse.tm.terminal.connector.local.feature.source.feature.group" version="10.6.2.202205081303"/>
+            <unit id="org.eclipse.tm.terminal.connector.remote.feature.feature.group" version="10.6.2.202205081303"/>
+            <unit id="org.eclipse.tm.terminal.connector.remote.feature.source.feature.group" version="10.6.2.202205081303"/>
+            <unit id="org.eclipse.tm.terminal.connector.ssh.feature.feature.group" version="10.6.2.202205081303"/>
+            <unit id="org.eclipse.tm.terminal.connector.ssh.feature.source.feature.group" version="10.6.2.202205081303"/>
+            <unit id="org.eclipse.tm.terminal.connector.telnet.feature.feature.group" version="10.6.2.202205081303"/>
+            <unit id="org.eclipse.tm.terminal.connector.telnet.feature.source.feature.group" version="10.6.2.202205081303"/>
+            <unit id="org.eclipse.tm.terminal.control.feature.feature.group" version="10.6.2.202205081303"/>
+            <unit id="org.eclipse.tm.terminal.control.feature.source.feature.group" version="10.6.2.202205081303"/>
+            <unit id="org.eclipse.tm.terminal.feature.feature.group" version="10.6.2.202205081303"/>
+            <unit id="org.eclipse.tm.terminal.feature.source.feature.group" version="10.6.2.202205081303"/>
+            <unit id="org.eclipse.tm.terminal.view.feature.feature.group" version="10.6.2.202205081303"/>
+            <unit id="org.eclipse.tm.terminal.view.feature.source.feature.group" version="10.6.2.202205081303"/>
+        </location>
+        <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
+            <repository location="http://download.eclipse.org/lsp4mp/releases/0.7.0/repository/"/>
+            <unit id="org.eclipse.lsp4mp.jdt.core" version="0.7.0.20230403-1449"/>
+        </location>
+        <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
+            <repository location="https://download.eclipse.org/jdtls/milestones/1.5.0/repository/"/>
+            <unit id="org.eclipse.jdt.ls.core" version="1.5.0.202110191539"/>
+        </location>
+        <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
+            <repository location="https://download.eclipse.org/buildship/updates/e423/releases/3.x/3.1.6.v20220511-1359/"/>
+            <unit id="org.eclipse.buildship.ui" version="3.1.6.v20220511-1359"/>
+        </location>
+        <location includeDependencyDepth="none" includeDependencyScopes="compile" missingManifest="generate" type="Maven">
+            <dependencies>
+                <dependency>
+                    <groupId>net.bytebuddy</groupId>
+                    <artifactId>byte-buddy-agent</artifactId>
+                    <version>1.12.17</version>
+                    <type>jar</type>
+                </dependency>
+                <dependency>
+                    <groupId>net.bytebuddy</groupId>
+                    <artifactId>byte-buddy</artifactId>
+                    <version>1.12.17</version>
+                    <type>jar</type>
+                </dependency>
+                <dependency>
+                    <groupId>org.mockito</groupId>
+                    <artifactId>mockito-core</artifactId>
+                    <version>4.8.0</version>
+                    <type>jar</type>
+                </dependency>
+                <dependency>
+                    <groupId>org.mockito</groupId>
+                    <artifactId>mockito-junit-jupiter</artifactId>
+                    <version>4.8.0</version>
+                    <type>jar</type>
+                </dependency>
+                <dependency>
+                    <groupId>org.objenesis</groupId>
+                    <artifactId>objenesis</artifactId>
+                    <version>3.3</version>
+                    <type>jar</type>
+                </dependency>
+            </dependencies>
+        </location>
+        <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
+            <repository location="https://download.eclipse.org/lsp4jakarta/releases/0.1.0/repository"/>
+            <unit id="org.eclipse.lsp4jakarta.jdt.core" version="0.0"/>
+        </location>
+                
+    </locations>
+</target>


### PR DESCRIPTION
upgrades target platform to the 2023-03 IDE level.

note: I did not change the level of org.eclipse.lsp4mp.jdt.core or org.eclipse.jdt.ls.core , just the IDE entries to move to 2023-03

In the past moving to the latest org.eclipse.jdt.ls.core from its current version of 1.5.0 caused the LS to fail to come up